### PR TITLE
Show turn counter in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ First version of Brogueasy, forked from Brogue Community Edition 1.9.3.
 -
   Added level feeling messages.
 -
+  Added turn counter to sidebar.
+-
   Updated Info.plist and Rogue.h to refer to "Brogueasy" instead of "CE".
 -
   Updated README.md to introduce Brogueasy.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Currently implemented:
   Removed the identification system. All items are identified upon creation.
 -
   Added "level feeling" messages when descending.
-
+-
+  Added turn counter to sidebar.
 
 TODO:
 

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4522,6 +4522,17 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
                 printString("                    ", 0, y, &white, &black, 0);
                 printString(buf, (20 - strLenWithoutEscapes(buf)) / 2, y++, (dim ? &darkGray : &gray), &black, 0);
             }
+
+            // Brogueasy: display turn counter
+            boolean showTurnCount = true;
+
+            if (showTurnCount) {
+               if (y < ROWS - 1) {
+                 sprintf(buf, "Turn: %li", rogue.playerTurnNumber);
+                 printString("                    ", 0, y, &white, &black, 0);
+                 printString(buf, (20 - strLenWithoutEscapes(buf)) / 2, y++, (dim ? &darkGray : &gray), &black, 0);
+               }
+            }
             if (y < ROWS - 1) {
                 tempColorEscape[0] = '\0';
                 grayColorEscape[0] = '\0';


### PR DESCRIPTION
A turn count display is sometimes the only indication that time has passed, in cases where nothing else is moving  on the screen. 

The changing turn counter gives players feedback that pressing `Shift+Z` is doing something (and helps them realize when they're pressing it instead of ` >`, for example).