### PR TITLE
Remove leftover traces of negative runics

### DIFF
--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -571,8 +571,8 @@ void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed) {
     char buf[DCOLS*3], monstName[DCOLS], theItemName[DCOLS];
 
     color *effectColors[NUMBER_WEAPON_RUNIC_KINDS] = {&white, &black,
-        &yellow, &pink, &green, &confusionGasColor, NULL, NULL, &darkRed, &rainbow};
-    //  W_SPEED, W_QUIETUS, W_PARALYSIS, W_MULTIPLICITY, W_SLOWING, W_CONFUSION, W_FORCE, W_SLAYING, W_MERCY, W_PLENTY
+        &yellow, &pink, &green, &confusionGasColor, NULL, NULL};
+    //  W_SPEED, W_QUIETUS, W_PARALYSIS, W_MULTIPLICITY, W_SLOWING, W_CONFUSION, W_FORCE, W_SLAYING
     short chance, i;
     fixpt enchant;
     enum weaponEnchants enchantType = theItem->enchant2;
@@ -1183,9 +1183,6 @@ boolean attack(creature *attacker, creature *defender, boolean lungeAttack) {
             }
             if (armorRunicString[0]) {
                 message(armorRunicString, false);
-                if (rogue.armor && (rogue.armor->flags & ITEM_RUNIC) && rogue.armor->enchant2 == A_BURDEN) {
-                    strengthCheck(rogue.armor);
-                }
             }
         }
 

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -775,7 +775,6 @@ enum weaponEnchants {
     W_CONFUSION,
     W_FORCE,
     W_SLAYING,
-    W_MERCY,
     NUMBER_WEAPON_RUNIC_KINDS
 };
 
@@ -798,7 +797,6 @@ enum armorEnchants {
     A_REFLECTION,
     A_RESPIRATION,
     A_DAMPENING,
-    A_BURDEN,
     NUMBER_ARMOR_ENCHANT_KINDS
 };
 


### PR DESCRIPTION
Enum values for weapon of mercy and armor of burden were left over. This caused these runics to still spawn but be broken and crash the game (due to their being removed from other places in the code), as reported in https://github.com/HomebrewHomunculus/BrogueLite/issues/14