### PR TITLE
Fix: show message when using door key from a stack of several

### DIFF
--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -440,6 +440,13 @@ void useKeyAt(item *theItem, short x, short y) {
       // Brogue Lite: fungiblek keys can stack, so shouldn't delete but decrement the stack instead
       if (theItem->quantity > 1) {
           theItem->quantity--;
+
+          itemName(theItem, buf2, true, false, NULL);
+          sprintf(buf, "you use one of your %ss %s %s.",
+                  buf2,
+                  preposition,
+                  terrainName);
+          messageWithColor(buf, &itemMessageColor, false);
         } else {
           if (removeItemFromChain(theItem, packItems)) {
               itemName(theItem, buf2, true, false, NULL);


### PR DESCRIPTION
In #27 , made door keys get combined into a stack in the inventory. Decremented their quantity when using on a door, but forgot to add the message "You use your...".

This adds the message "You use one of your iron keys on the door." when you have more than one in a stack.
